### PR TITLE
References to single-file version on Installation page

### DIFF
--- a/tt/install.ttml
+++ b/tt/install.ttml
@@ -33,7 +33,7 @@
 
     <p>
     The
-    <a href="ack-single-file">single-file version of ack</a>
+    <a href="ack-2.00-single-file">single-file version of ack</a>
     is a single Perl program, around 2,800 lines of plain text.  It
     combines the ack program and all its Perl modules into a single
     text file you can download and install anywhere you can put a
@@ -43,7 +43,7 @@
     </p>
 
     <blockquote><code>
-    curl http://beyondgrep.com/ack-standalone &gt; ~/bin/ack &amp;&amp; chmod 0755 !#:3
+    curl http://beyondgrep.com/ack-2.00-single-file &gt; ~/bin/ack &amp;&amp; chmod 0755 !#:3
     </code></blockquote>
 
     <h2>Install a package for your specific OS</h2>


### PR DESCRIPTION
Hey Andy!  Hope I can help a bit. :)

---

At the Installation page, two references to the single-file (previously referred to as "standalone") version of Ack 2.0 are currently leading to nowhere: 
1. The paragraph text has an anchor pointing to `ack-single-file`
2. The example `curl(1)` command refers to `ack-standalone`

The only choices in `static/` are actually:
- `ack-1.96-single-file`
- `ack-2.00-single-file`

Included commit points both references to `ack-2.00-single-file`.
