### PR TITLE
features: specify that ag supports --column

### DIFF
--- a/features.json
+++ b/features.json
@@ -382,7 +382,7 @@
                 "what": "Show the column number of the first match",
                 "how": {
                     "ack": "--[no-]column",
-                    "rg": "--column"
+                    "ag,rg": "--column"
                 }
             },
             {


### PR DESCRIPTION
This has been a feature of the tool since
ggreer/the_silver_searcher@954cc54 ("Add support for --column",
2011-12-27), but wasn't listed in this comparison.