### PR TITLE
features: git-grep can search outside of git repositories

### DIFF
--- a/features.json
+++ b/features.json
@@ -62,7 +62,7 @@
                 "what": "Search where",
                 "how": {
                     "ack,ag,gnu,rg": "anywhere",
-                    "git": "git repository only"
+                    "git": "anywhere, git repository only by default (unless --no-index)"
                 }
             },
             {


### PR DESCRIPTION
Correct a misconception in f22b409 ("More git goodness", 2018-01-27),
hopefully this doesn't overflow the comparison.

By default git-grep doesn't search outside repositories, and will just
error out, but that's just because you haven't supplied --no-index,
this'll work to search foo.*bar on the whole FS, just like GNU grep et
al.

    (cd / && git grep --no-index foo.*bar)