### PR TITLE
rg's regex engine is not Perl-compatible.

### DIFF
--- a/features.json
+++ b/features.json
@@ -50,7 +50,7 @@
                     "gnu": "basic, extended, Perl-compatible (experimental)",
                     "ack": "native Perl",
                     "ag": "Perl-compatible",
-                    "rg": "Perl-compatible"
+                    "rg": "Finite automata-based. https://docs.rs/regex/0.2.5/regex/#syntax"
                 }
             }
         ]


### PR DESCRIPTION
Ripgrep uses Rust's regex library, which is not strictly Perl-compatible. It's a linear-time finite-automata-based implementation, similar to RE2.