### PR TITLE
broken links in HTML man pages, issue #27

### DIFF
--- a/static/documentation/ack-2.00-man.html
+++ b/static/documentation/ack-2.00-man.html
@@ -112,9 +112,9 @@ to the given PATTERN.  By default, ack prints the matching lines.</p>
 <p>PATTERN is a Perl regular expression.  Perl regular expressions
 are commonly found in other programming languages, but for the particulars
 of their behavior, please consult
-<a href="http://perldoc.perl.org/perlreref.html|perlreref">http://perldoc.perl.org/perlreref.html|perlreref</a>.  If you don't know
+<a href="http://perldoc.perl.org/perlreref.html">perlreref</a>.  If you don't know
 how to use regular expression but are interested in learning, you may
-consult <a href="http://perldoc.perl.org/perlretut.html|perlretut">http://perldoc.perl.org/perlretut.html|perlretut</a>.  If you do not
+consult <a href="http://perldoc.perl.org/perlretut.html">perlretut</a>.  If you do not
 need or want ack to use regular expressions, please see the
 <code>-Q</code>/<code>--literal</code> option.</p>
 <p>Ack can also list files that would be searched, without actually
@@ -878,7 +878,7 @@ the previous five lines from the log in each case.</p>
 </dd>
 </dl>
 <p>For more details and other variables see
-<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar">http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar</a>.</p>
+<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions">perlvar</a>.</p>
 <p>This example shows how to add text around a particular pattern
 (in this case adding _ around word with &quot;e&quot;)</p>
 <pre>

--- a/static/documentation/ack-2.02-man.html
+++ b/static/documentation/ack-2.02-man.html
@@ -112,9 +112,9 @@ to the given PATTERN.  By default, ack prints the matching lines.</p>
 <p>PATTERN is a Perl regular expression.  Perl regular expressions
 are commonly found in other programming languages, but for the particulars
 of their behavior, please consult
-<a href="http://perldoc.perl.org/perlreref.html|perlreref">http://perldoc.perl.org/perlreref.html|perlreref</a>.  If you don't know
+<a href="http://perldoc.perl.org/perlreref.html">perlreref</a>.  If you don't know
 how to use regular expression but are interested in learning, you may
-consult <a href="http://perldoc.perl.org/perlretut.html|perlretut">http://perldoc.perl.org/perlretut.html|perlretut</a>.  If you do not
+consult <a href="http://perldoc.perl.org/perlretut.html">perlretut</a>.  If you do not
 need or want ack to use regular expressions, please see the
 <code>-Q</code>/<code>--literal</code> option.</p>
 <p>Ack can also list files that would be searched, without actually
@@ -882,7 +882,7 @@ the previous five lines from the log in each case.</p>
 </dd>
 </dl>
 <p>For more details and other variables see
-<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar">http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar</a>.</p>
+<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions">perlvar</a>.</p>
 <p>This example shows how to add text around a particular pattern
 (in this case adding _ around word with &quot;e&quot;)</p>
 <pre>

--- a/static/documentation/ack-2.04-man.html
+++ b/static/documentation/ack-2.04-man.html
@@ -112,9 +112,9 @@ to the given PATTERN.  By default, ack prints the matching lines.</p>
 <p>PATTERN is a Perl regular expression.  Perl regular expressions
 are commonly found in other programming languages, but for the particulars
 of their behavior, please consult
-<a href="http://perldoc.perl.org/perlreref.html|perlreref">http://perldoc.perl.org/perlreref.html|perlreref</a>.  If you don't know
+<a href="http://perldoc.perl.org/perlreref.html">perlreref</a>.  If you don't know
 how to use regular expression but are interested in learning, you may
-consult <a href="http://perldoc.perl.org/perlretut.html|perlretut">http://perldoc.perl.org/perlretut.html|perlretut</a>.  If you do not
+consult <a href="http://perldoc.perl.org/perlretut.html">perlretut</a>.  If you do not
 need or want ack to use regular expressions, please see the
 <code>-Q</code>/<code>--literal</code> option.</p>
 <p>Ack can also list files that would be searched, without actually
@@ -882,7 +882,7 @@ the previous five lines from the log in each case.</p>
 </dd>
 </dl>
 <p>For more details and other variables see
-<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar">http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar</a>.</p>
+<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions">perlvar</a>.</p>
 <p>This example shows how to add text around a particular pattern
 (in this case adding _ around word with &quot;e&quot;)</p>
 <pre>

--- a/static/documentation/ack-2.08-man.html
+++ b/static/documentation/ack-2.08-man.html
@@ -112,9 +112,9 @@ to the given PATTERN.  By default, ack prints the matching lines.</p>
 <p>PATTERN is a Perl regular expression.  Perl regular expressions
 are commonly found in other programming languages, but for the particulars
 of their behavior, please consult
-<a href="http://perldoc.perl.org/perlreref.html|perlreref">http://perldoc.perl.org/perlreref.html|perlreref</a>.  If you don't know
+<a href="http://perldoc.perl.org/perlreref.html">perlreref</a>.  If you don't know
 how to use regular expression but are interested in learning, you may
-consult <a href="http://perldoc.perl.org/perlretut.html|perlretut">http://perldoc.perl.org/perlretut.html|perlretut</a>.  If you do not
+consult <a href="http://perldoc.perl.org/perlretut.html">perlretut</a>.  If you do not
 need or want ack to use regular expressions, please see the
 <code>-Q</code>/<code>--literal</code> option.</p>
 <p>Ack can also list files that would be searched, without actually
@@ -892,7 +892,7 @@ the previous five lines from the log in each case.</p>
 </dd>
 </dl>
 <p>For more details and other variables see
-<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar">http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar</a>.</p>
+<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions">perlvar</a>.</p>
 <p>This example shows how to add text around a particular pattern
 (in this case adding _ around word with &quot;e&quot;)</p>
 <pre>

--- a/static/documentation/ack-2.12-man.html
+++ b/static/documentation/ack-2.12-man.html
@@ -126,9 +126,9 @@ to the given PATTERN.  By default, ack prints the matching lines.</p>
 <p>PATTERN is a Perl regular expression.  Perl regular expressions
 are commonly found in other programming languages, but for the particulars
 of their behavior, please consult
-<a href="http://perldoc.perl.org/perlreref.html|perlreref">http://perldoc.perl.org/perlreref.html|perlreref</a>.  If you don't know
+<a href="http://perldoc.perl.org/perlreref.html">perlreref</a>.  If you don't know
 how to use regular expression but are interested in learning, you may
-consult <a href="http://perldoc.perl.org/perlretut.html|perlretut">http://perldoc.perl.org/perlretut.html|perlretut</a>.  If you do not
+consult <a href="http://perldoc.perl.org/perlretut.html">perlretut</a>.  If you do not
 need or want ack to use regular expressions, please see the
 <code>-Q</code>/<code>--literal</code> option.</p>
 <p>Ack can also list files that would be searched, without actually
@@ -908,7 +908,7 @@ the previous five lines from the log in each case.</p>
 </dd>
 </dl>
 <p>For more details and other variables see
-<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar">http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar</a>.</p>
+<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions">perlvar</a>.</p>
 <p>This example shows how to add text around a particular pattern
 (in this case adding _ around word with &quot;e&quot;)</p>
 <pre>

--- a/static/documentation/ack-2.14-man.html
+++ b/static/documentation/ack-2.14-man.html
@@ -119,9 +119,9 @@ to the given PATTERN.  By default, ack prints the matching lines.</p>
 <p>PATTERN is a Perl regular expression.  Perl regular expressions
 are commonly found in other programming languages, but for the particulars
 of their behavior, please consult
-<a href="http://perldoc.perl.org/perlreref.html|perlreref">http://perldoc.perl.org/perlreref.html|perlreref</a>.  If you don't know
+<a href="http://perldoc.perl.org/perlreref.html">perlreref</a>.  If you don't know
 how to use regular expression but are interested in learning, you may
-consult <a href="http://perldoc.perl.org/perlretut.html|perlretut">http://perldoc.perl.org/perlretut.html|perlretut</a>.  If you do not
+consult <a href="http://perldoc.perl.org/perlretut.html">perlretut</a>.  If you do not
 need or want ack to use regular expressions, please see the
 <code>-Q</code>/<code>--literal</code> option.</p>
 <p>Ack can also list files that would be searched, without actually
@@ -925,7 +925,7 @@ the previous five lines from the log in each case.</p>
 </dd>
 </dl>
 <p>For more details and other variables see
-<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar">http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar</a>.</p>
+<a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions">perlvar</a>.</p>
 <p>This example shows how to add text around a particular pattern
 (in this case adding _ around word with &quot;e&quot;)</p>
 <pre>

--- a/static/documentation/ack-2.16-man.html
+++ b/static/documentation/ack-2.16-man.html
@@ -99,7 +99,7 @@
 
 <p>Ack searches the named input FILEs (or standard input if no files are named, or the file name - is given) for lines containing a match to the given PATTERN. By default, ack prints the matching lines.</p>
 
-<p>PATTERN is a Perl regular expression. Perl regular expressions are commonly found in other programming languages, but for the particulars of their behavior, please consult <a href="http://perldoc.perl.org/perlreref.html|perlreref">http://perldoc.perl.org/perlreref.html|perlreref</a>. If you don&#39;t know how to use regular expression but are interested in learning, you may consult <a href="http://perldoc.perl.org/perlretut.html|perlretut">http://perldoc.perl.org/perlretut.html|perlretut</a>. If you do not need or want ack to use regular expressions, please see the <code>-Q</code>/<code>--literal</code> option.</p>
+<p>PATTERN is a Perl regular expression. Perl regular expressions are commonly found in other programming languages, but for the particulars of their behavior, please consult <a href="http://perldoc.perl.org/perlreref.html">perlreref</a>. If you don&#39;t know how to use regular expression but are interested in learning, you may consult <a href="http://perldoc.perl.org/perlretut.html">perlretut</a>. If you do not need or want ack to use regular expressions, please see the <code>-Q</code>/<code>--literal</code> option.</p>
 
 <p>Ack can also list files that would be searched, without actually searching them, to let you take advantage of ack&#39;s file-type filtering capabilities.</p>
 
@@ -846,7 +846,7 @@
 </dd>
 </dl>
 
-<p>For more details and other variables see <a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar">http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar</a>.</p>
+<p>For more details and other variables see <a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions">perlvar</a>.</p>
 
 <p>This example shows how to add text around a particular pattern (in this case adding _ around word with &quot;e&quot;)</p>
 

--- a/static/documentation/ack-2.18-man.html
+++ b/static/documentation/ack-2.18-man.html
@@ -113,7 +113,7 @@
 
 <p>ack searches the named input FILEs or DIRECTORYs for lines containing a match to the given PATTERN. By default, ack prints the matching lines. If no FILE or DIRECTORY is given, the current directory will be searched.</p>
 
-<p>PATTERN is a Perl regular expression. Perl regular expressions are commonly found in other programming languages, but for the particulars of their behavior, please consult <a href="http://perldoc.perl.org/perlreref.html|perlreref">http://perldoc.perl.org/perlreref.html|perlreref</a>. If you don&#39;t know how to use regular expression but are interested in learning, you may consult <a href="http://perldoc.perl.org/perlretut.html|perlretut">http://perldoc.perl.org/perlretut.html|perlretut</a>. If you do not need or want ack to use regular expressions, please see the <code>-Q</code>/<code>--literal</code> option.</p>
+<p>PATTERN is a Perl regular expression. Perl regular expressions are commonly found in other programming languages, but for the particulars of their behavior, please consult <a href="http://perldoc.perl.org/perlreref.html">perlreref</a>. If you don&#39;t know how to use regular expression but are interested in learning, you may consult <a href="http://perldoc.perl.org/perlretut.html">perlretut</a>. If you do not need or want ack to use regular expressions, please see the <code>-Q</code>/<code>--literal</code> option.</p>
 
 <p>Ack can also list files that would be searched, without actually searching them, to let you take advantage of ack&#39;s file-type filtering capabilities.</p>
 
@@ -866,7 +866,7 @@
 </dd>
 </dl>
 
-<p>For more details and other variables see <a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar">http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions|perlvar</a>.</p>
+<p>For more details and other variables see <a href="http://perldoc.perl.org/perlvar.html#Variables-related-to-regular-expressions">perlvar</a>.</p>
 
 <p>This example shows how to add text around a particular pattern (in this case adding _ around word with &quot;e&quot;)</p>
 


### PR DESCRIPTION
I'm only skimming your repository and haven't found how the HTML files are generated; if you could kindly point me where it is done, I suppose I could try to fix it upstream.

The fact I'm not a Perl monger shows, sorry for the many attemps:

```shell
sed -r 's/"([^"]*.html[^|]*)\|[^"]*"/"\1"/g;s#>http://perldoc[^<|]*\|#>#g' -i static/documentation/*html
```