### PR TITLE
SEO: expose Bill The Cat logo

### DIFF
--- a/tt/google.tt
+++ b/tt/google.tt
@@ -9,3 +9,11 @@
   ga('send', 'pageview');
 
 </script>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "Organization",
+  "url": "https://beyondgrep.com/",
+  "logo": "https://avatars0.githubusercontent.com/u/30610360"
+}
+</script>


### PR DESCRIPTION
Following Google guidelines:
https://developers.google.com/search/docs/data-types/logo

Note: I have not found your logo in your repositories so I linked it to the GitHub version; edit as you like.