### PR TITLE
Add Sourcegraph to list of indexing tools

### DIFF
--- a/tt/more-tools.ttml
+++ b/tt/more-tools.ttml
@@ -357,6 +357,21 @@
     [% WRAPPER selflink.tt %]https://github.com/etsy/Hound[% END %]
     </p>
 
+    <h2>Sourcegraph</h2>
+    <p>
+    Sourcegraph is a horizontally scalable code search engine that
+    supports regex, symbol search, and the <a href="https://comby.dev/">Comby pattern syntax</a>.
+    It also has code navigation supported by a combination of the
+    <a href="https://microsoft.github.io/language-server-protocol/specifications/lsif/0.4.0/specification/">Language Server Index Format</a>
+    and a ctags-like backend. The core application is open source, but
+    enterprise features such as SSO are available only in a proprietary
+    version of the application.
+    </p>
+
+    <p>
+    [% WRAPPER selflink.tt %]https://sourcegraph.com[% END %]
+    </p>
+
 </div>
 
 [% END %]


### PR DESCRIPTION
Would it be appropriate to add Sourcegraph (https://github.com/sourcegraph/sourcegraph) to the list of indexing tools on the web page? It looks like the other tools listed are open source, while Sourcegraph is open core (main application is open-source, but there's an enterprise version that contains proprietary code for things like SSO). Unsure if that rules it out of this list, but a lot of our customers were using one of the indexing tools listed here (e.g., OpenGrok, Hound, cscope) before they adopted Sourcegraph, so thought it might be a worthy addition . If not, feel free to close and sorry about the noise!

P.S. thanks for creating this useful resource for people looking for better code search utilities. I've used ack a lot over the years, its speed and usability are fantastic, and from my vantage point (I used `ack` before anything else), it kicked off the explosion of better grep alternatives listed here!