### PR TITLE
add `git grep` to `--only-matching`-capable utilities

### DIFF
--- a/features.json
+++ b/features.json
@@ -324,7 +324,7 @@
                 "what": "Show only the part of a line that matched",
                 "how": {
                     "ack": "-o",
-                    "ag,freebsd,gnu,osx,rg": "-o --only-matching"
+                    "ag,freebsd,git,gnu,osx,rg": "-o --only-matching"
                 }
             },
             {


### PR DESCRIPTION
`git grep -o` (`git grep --only-matching`) has been able to print only the matched parts of a line since [v2.19.0 released in 2018](https://git.kernel.org/pub/scm/git/git.git/commit/?id=9d8db06eb4a5d5577db559a0059a377914c1ce5a). This commit may fix #133.